### PR TITLE
bug fix for torch.max operation

### DIFF
--- a/model.py
+++ b/model.py
@@ -491,7 +491,8 @@ class SSD300(nn.Module):
 
                     # Suppress boxes whose overlaps (with this box) are greater than maximum overlap
                     # Find such boxes and update suppress indices
-                    suppress = torch.max(suppress, overlap[box] > max_overlap)
+                    overlap_above_max = (overlap[box] > max_overlap).byte()
+                    suppress = torch.max(suppress, overlap_above_max)
                     # The max operation retains previously suppressed boxes, like an 'OR' operation
 
                     # Don't suppress this box, even though it has an overlap of 1 with itself


### PR DESCRIPTION
RuntimeError: Expected object of scalar type Byte but got scalar type Bool for argument #2 'other' in call to _th_max